### PR TITLE
[BUGFIX] Drop legacy usage of `develop` branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,6 @@ updates:
       interval: daily
     commit-message:
       prefix: '[TASK]'
-    target-branch: develop
     labels:
       - dependencies
     open-pull-requests-limit: 10

--- a/.github/workflows/cgl.yaml
+++ b/.github/workflows/cgl.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - develop
   pull_request:
     branches:
       - '**'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - develop
   pull_request:
     branches:
       - '**'


### PR DESCRIPTION
With this PR, all legacy usages of the `develop` branch were removed.