### PR TITLE
[TASK] Move `spomky-labs/otphp` to package suggestions

### DIFF
--- a/.github/workflows/cgl.yaml
+++ b/.github/workflows/cgl.yaml
@@ -29,11 +29,15 @@ jobs:
 
       # Install dependencies
       - name: Install Composer dependencies
-        run: composer update --no-progress
+        run: composer require --no-progress spomky-labs/otphp:"^11.0"
 
       # Check Composer dependencies
       - name: Check dependencies
         run: composer-require-checker check
+      - name: Reset composer.json
+        run: |
+          git checkout composer.json
+          composer update --no-progress
       - name: Check for unused dependencies
         run: composer-unused
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ The following authorization methods are currently available:
 at your cPanel instance. For this, you have to implement the interface
 [`Application\Authorization\AuthorizationInterface`](src/Application/Authorization/AuthorizationInterface.php).
 
+:warning: If you want to use two-factor authentication together with
+the HTTP session authorization method, you must require the
+`spomky-labs/otphp` package.
+
 ### Create a new [`CPanel`](src/Application/CPanel.php) instance
 
 Once you have selected an authentication method, you can create a

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
         "psr/http-message": "^1.0",
-        "spomky-labs/otphp": "^11.0",
         "symfony/console": "^6.0",
         "symfony/filesystem": "^6.0",
         "symfony/finder": "^6.0"
@@ -35,8 +34,13 @@
         "phpstan/phpstan": "^1.8",
         "phpstan/phpstan-phpunit": "^1.1",
         "phpstan/phpstan-strict-rules": "^1.2",
-        "phpunit/phpunit": "^9.5.5"
+        "phpunit/phpunit": "^9.5.5",
+        "spomky-labs/otphp": "^11.0",
+        "thecodingmachine/safe": "^2.0"
     },
+	"suggest": {
+		"spomky-labs/otphp": "Used for authentication via HTTP session (^11.0)"
+	},
     "autoload": {
         "psr-4": {
             "EliasHaeussler\\CpanelRequests\\": "src"


### PR DESCRIPTION
The `spomky-labs/otphp` package is no longer required, since alternative authentication methods are available. In case one uses the HTTP session authentication method, he needs to require the package by its own.