### PR TITLE
[BUGFIX] Normalize path segments in Uri builders

### DIFF
--- a/src/Http/UriBuilder/DefaultUriBuilder.php
+++ b/src/Http/UriBuilder/DefaultUriBuilder.php
@@ -30,6 +30,7 @@ use function array_merge;
 use function explode;
 use function http_build_query;
 use function implode;
+use function ltrim;
 use function parse_str;
 
 /**
@@ -52,7 +53,7 @@ final class DefaultUriBuilder implements UriBuilderInterface
         parse_str($request->getBaseUri()->getQuery(), $queryParams);
 
         return $request->getBaseUri()
-            ->withPath('/'.$path)
+            ->withPath('/'.ltrim($path, '/'))
             ->withQuery(http_build_query($queryParams + $request->getParameters()))
         ;
     }

--- a/src/Http/UriBuilder/SessionBasedUriBuilder.php
+++ b/src/Http/UriBuilder/SessionBasedUriBuilder.php
@@ -30,6 +30,7 @@ use Psr\Http\Message;
 use function array_filter;
 use function http_build_query;
 use function implode;
+use function ltrim;
 
 /**
  * SessionBasedUriBuilder.
@@ -62,7 +63,7 @@ final class SessionBasedUriBuilder implements UriBuilderInterface
         parse_str($request->getBaseUri()->getQuery(), $queryParams);
 
         return $request->getBaseUri()
-            ->withPath('/'.$path)
+            ->withPath('/'.ltrim($path, '/'))
             ->withQuery(http_build_query($queryParams + $request->getParameters()))
         ;
     }

--- a/src/Http/UriBuilder/TokenBasedUriBuilder.php
+++ b/src/Http/UriBuilder/TokenBasedUriBuilder.php
@@ -25,6 +25,7 @@ namespace EliasHaeussler\CpanelRequests\Http\UriBuilder;
 
 use EliasHaeussler\CpanelRequests\Http;
 use Psr\Http\Message;
+use function ltrim;
 
 /**
  * TokenBasedUriBuilder.
@@ -47,7 +48,7 @@ final class TokenBasedUriBuilder implements UriBuilderInterface
         parse_str($request->getBaseUri()->getQuery(), $queryParams);
 
         return $request->getBaseUri()
-            ->withPath('/'.$path)
+            ->withPath('/'.ltrim($path, '/'))
             ->withQuery(http_build_query($queryParams + $request->getParameters()))
         ;
     }


### PR DESCRIPTION
With this PR, leading slashes are removed from paths built by Uri builders.