### PR TITLE
[BUGFIX] Run `composer install` in CI

### DIFF
--- a/.github/workflows/cgl.yaml
+++ b/.github/workflows/cgl.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Reset composer.json
         run: |
           git checkout composer.json
-          composer update --no-progress
+          composer install --no-progress
       - name: Check for unused dependencies
         run: composer-unused
 


### PR DESCRIPTION
Since ac3d5d1303854c423fa83c38179c96c7e0c5fc8f, the `composer.lock` file is present in this repository. Therefore, CI should perform `composer install` instead of `composer update` since Dependabot takes care of updating dependencies.