### PR TITLE
[TASK] Run Dependabot updates daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,8 +15,7 @@ updates:
   - package-ecosystem: composer
     directory: '/'
     schedule:
-      interval: weekly
-      day: friday
+      interval: daily
     commit-message:
       prefix: '[TASK]'
     labels:


### PR DESCRIPTION
With this PR, Dependabot updates for Composer dependencies are now run daily instead of only on Fridays.