### PR TITLE
[BUGFIX] Run dependabot auto-merge action on PR open only

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -1,5 +1,7 @@
 name: Dependabot auto-merge
-on: [pull_request]
+on:
+  pull_request:
+    types: [opened]
 
 jobs:
   dependabot-auto-merge:


### PR DESCRIPTION
This avoids a lot of merge comments which are in fact just needed once.