### PR TITLE
[TASK] Use latest version of `composer-unused`

### DIFF
--- a/.github/workflows/cgl.yaml
+++ b/.github/workflows/cgl.yaml
@@ -20,7 +20,8 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: 8.2
-          tools: composer:v2, composer-require-checker, composer-unused:0.7, cs2pr
+          tools: composer:v2, composer-require-checker, composer-unused, cs2pr
+          coverage: none
 
       # Validation
       - name: Validate composer.json


### PR DESCRIPTION
This PR switches to the latest version of `composer-unused` in CGL workflow.