### PR TITLE
[TASK] Use Config API from eliashaeussler/phpstan-config

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,7 +7,7 @@
 /.php-cs-fixer.php      export-ignore
 /codecov.yml            export-ignore
 /composer.lock          export-ignore
-/phpstan.neon           export-ignore
+/phpstan.php            export-ignore
 /phpunit.xml            export-ignore
 /rector.php             export-ignore
 /renovate.json          export-ignore

--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,7 @@
         "sca": [
             "@sca:php"
         ],
-        "sca:php": "phpstan analyse -c phpstan.neon",
+        "sca:php": "phpstan analyse -c phpstan.php",
         "test": "@test:coverage --no-coverage",
         "test:coverage": "phpunit -c phpunit.xml"
     }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,7 +1,0 @@
-includes:
-	- vendor/phpstan/phpstan/conf/bleedingEdge.neon
-parameters:
-	level: max
-	paths:
-		- src
-		- tests

--- a/phpstan.php
+++ b/phpstan.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cpanel-requests".
+ *
+ * Copyright (C) 2023 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+return \EliasHaeussler\PHPStanConfig\Config\Config::create(__DIR__)
+    ->in(
+        'src',
+        'tests',
+    )
+    ->withBleedingEdge()
+    ->maxLevel()
+    ->toArray()
+;


### PR DESCRIPTION
This PR converts `phpstan.neon` to `phpstan.php` and uses the Config API from `eliashaeussler/phpstan-config`.