### PR TITLE
[TASK] Stabilize coverage reporting in CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,9 +5,6 @@ on:
       - main
       - 'renovate/**'
   pull_request:
-    branches:
-      - '**'
-      - '!renovate/**'
 
 jobs:
   tests:
@@ -36,7 +33,6 @@ jobs:
         uses: ramsey/composer-install@v2
         with:
           dependency-versions: ${{ matrix.dependencies }}
-          composer-options: ${{ matrix.composer-options }}
 
       # Run tests
       - name: Run tests
@@ -68,21 +64,49 @@ jobs:
       - name: Run tests with coverage
         run: composer test:coverage
 
-      # Report coverage
+      # Upload artifact
       - name: Fix coverage path
         working-directory: .build/coverage
         run: sed -i 's#/home/runner/work/cpanel-requests/cpanel-requests#${{ github.workspace }}#g' clover.xml
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage
+          path: .build/coverage/clover.xml
+          retention-days: 7
+
+  coverage-report:
+    name: Report test coverage
+    runs-on: ubuntu-latest
+    needs: coverage
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Download artifact
+      - name: Download coverage artifact
+        id: download
+        uses: actions/download-artifact@v3
+        with:
+          name: coverage
+
+      # CodeClimate
       - name: CodeClimate report
         uses: paambaati/codeclimate-action@v5.0.0
+        if: env.CC_TEST_REPORTER_ID
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
         with:
           coverageLocations: |
-            ${{ github.workspace }}/.build/coverage/clover.xml:clover
+            ${{ steps.download.outputs.download-path }}/clover.xml:clover
+
+      # codecov
       - name: codecov report
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          directory: .build/coverage
+          files: |
+            ${{ steps.download.outputs.download-path }}/clover.xml
           fail_ci_if_error: true
           verbose: true


### PR DESCRIPTION
This PR separates coverage collection and reporting by using different dependent jobs. This way, a failed coverage reporting does not require the whole test run to be repeated. 